### PR TITLE
Create Entity instead of User on Account creation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -206,7 +206,7 @@ $(document).ready(function () {
          Usergrid.validation.validatePassword(password, function (){
           $("#new-password").focus();
           $("#new-password").addClass('error');})  ) {
-      appUser = new Usergrid.User(); //make sure we have a clean user, and then add the data
+      appUser = new Usergrid.Entity('user'); //make sure we have a clean user, and then add the data
       appUser.set({"name":name,"username":username,"email":email,"password":password});
       appUser.save(
         function () {


### PR DESCRIPTION
Fixes a bug wherein the app still referenced the SDK class “User” which was deprecated a little while ago.
