### PR TITLE
Don’t force show my feed after following a user

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -482,7 +482,7 @@ $(document).ready(function () {
     Usergrid.ApiClient.runAppQuery(new Usergrid.Query('POST', 'users/' + appUser.get('username') + '/following/users/' + username, null, null,
       function() {
         $('#now-following-text').html('Congratulations! You are now following <strong>' + username + '</strong>');
-        showMyFeed();
+        //showMyFeed();
       },
       function() {
         $('#now-following-text').html('Aw Shucks!  There was a problem trying to follow <strong>' + username + '</strong>');


### PR DESCRIPTION
The UI flashes a dialog and forces a refresh right after a follow. This disables that.
