### PR TITLE
Disable auto-refresh to clear up logs.

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -599,7 +599,7 @@ $(document).ready(function () {
   var feedReloadTimer = window.setInterval( timerRefreshView, 30000 );
 
   function timerRefreshView(){
-    if (Usergrid.ApiClient.isLoggedInAppUser()) {
+    /* if (Usergrid.ApiClient.isLoggedInAppUser()) {
       if (fullFeedView) {
         showFullFeed();
       } else {
@@ -608,7 +608,8 @@ $(document).ready(function () {
     } else {
       window.location = "#page-login";
       return;
-    }
+    } */
+    return;
   }
 
 });


### PR DESCRIPTION
We auto-refresh the feed right now and that could be confusing to users. It also generates a lot of extra curl calls in the logs, which makes it hard for people to understand what is happening with the app if they learn from it. This disables it.
